### PR TITLE
feat(ui): add mainBox id to main content container

### DIFF
--- a/week-3.html
+++ b/week-3.html
@@ -186,7 +186,7 @@
       <div class="grid lg:grid-cols-3 gap-6 lg:gap-8">
 
         <div class="lg:col-span-2 space-y-6">
-          <div class="border border-gray-700 border-opacity-70 rounded-2xl lg:p-5 p-3 pt-5 slide-left lg:h-[calc(100vh-220px)] lg:w-full w-[calc(100vw-10px)]">
+          <div class="border border-gray-700 border-opacity-70 rounded-2xl lg:p-5 p-3 pt-5 slide-left lg:h-[calc(100vh-220px)] lg:w-full w-[calc(100vw-10px)]" id="mainBox">
 
             <div class="flex items-center justify-between mb-6">
               <div class="tab-buttons flex gap-1 relative bg-white/5 rounded-full p-1 backdrop-blur-md border border-white/10">


### PR DESCRIPTION
Adds the id="mainBox" attribute to the primary content container element.

This change is necessary to enable the new custom swipe gesture logic for navigating between tabs on touch devices, as the JavaScript relies on this specific ID to attach touchstart, touchmove, and touchend event listeners.